### PR TITLE
Add (void) casts to cloudabi_sys_clock_time_get calls.

### DIFF
--- a/src/libc/sys/resource/getrusage.c
+++ b/src/libc/sys/resource/getrusage.c
@@ -13,8 +13,8 @@ int getrusage(int who, struct rusage *r_usage) {
   switch (who) {
     case RUSAGE_SELF: {
       cloudabi_timestamp_t usertime = 0;
-      cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 1000,
-                                  &usertime);
+      (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 1000,
+                                        &usertime);
       *r_usage = (struct rusage){
           .ru_utime = timestamp_to_timeval(usertime),
       };

--- a/src/libc/sys/time/gettimeofday.c
+++ b/src/libc/sys/time/gettimeofday.c
@@ -10,7 +10,7 @@
 
 int gettimeofday(struct timeval *restrict tp, ...) {
   cloudabi_timestamp_t ts = 0;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_REALTIME, 1000, &ts);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_REALTIME, 1000, &ts);
   *tp = timestamp_to_timeval(ts);
   return 0;
 }

--- a/src/libc/sys/times/times.c
+++ b/src/libc/sys/times/times.c
@@ -15,11 +15,11 @@ static_assert(CLOCKS_PER_SEC == NSEC_PER_SEC,
 clock_t times(struct tms *buffer) {
   // Obtain user time.
   cloudabi_timestamp_t usertime = 0;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 0, &usertime);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 0, &usertime);
   *buffer = (struct tms){.tms_utime = usertime};
 
   // Obtain real time.
   cloudabi_timestamp_t realtime = 0;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_MONOTONIC, 0, &realtime);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_MONOTONIC, 0, &realtime);
   return realtime;
 }

--- a/src/libc/time/clock.c
+++ b/src/libc/time/clock.c
@@ -13,6 +13,6 @@ static_assert(CLOCKS_PER_SEC == NSEC_PER_SEC,
 
 clock_t clock(void) {
   cloudabi_timestamp_t ts = 0;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 0, &ts);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 0, &ts);
   return ts;
 }

--- a/src/libc/time/time.c
+++ b/src/libc/time/time.c
@@ -9,7 +9,7 @@
 
 time_t time(time_t *tloc) {
   cloudabi_timestamp_t ts = 0;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_REALTIME, NSEC_PER_SEC, &ts);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_REALTIME, NSEC_PER_SEC, &ts);
   if (tloc != NULL)
     *tloc = ts / NSEC_PER_SEC;
   return ts / NSEC_PER_SEC;

--- a/src/libc/uv/uv_getrusage.c
+++ b/src/libc/uv/uv_getrusage.c
@@ -8,8 +8,8 @@
 
 int uv_getrusage(uv_rusage_t *rusage) {
   cloudabi_timestamp_t usertime = 0;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 1000,
-                              &usertime);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_PROCESS_CPUTIME_ID, 1000,
+                                    &usertime);
   *rusage = (uv_rusage_t){
       .ru_utime.tv_sec = usertime / 1000000000,
       .ru_utime.tv_usec = (usertime % 1000000000) / 1000,

--- a/src/libc/uv/uv_hrtime.c
+++ b/src/libc/uv/uv_hrtime.c
@@ -7,6 +7,6 @@
 
 uint64_t uv_hrtime(void) {
   cloudabi_timestamp_t ts;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_MONOTONIC, 1, &ts);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_MONOTONIC, 1, &ts);
   return ts;
 }

--- a/src/libc/uv/uv_update_time.c
+++ b/src/libc/uv/uv_update_time.c
@@ -7,6 +7,6 @@
 
 void uv_update_time(uv_loop_t *loop) {
   cloudabi_timestamp_t ts;
-  cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_MONOTONIC, 1000000, &ts);
+  (void)cloudabi_sys_clock_time_get(CLOUDABI_CLOCK_MONOTONIC, 1000000, &ts);
   loop->__now = ts / 1000000;
 }


### PR DESCRIPTION
Add (void) to calls to cloudabi_sys_clock_time_get where the return
value is unused.

This allows the cloudabi_sys_* functions to be declared with
`__attribute__((warn_unused_result))` without introducing warnings in
cloudlibc.