### PR TITLE
Include <time.h> when calling time(2).

### DIFF
--- a/src/libc/unistd/sleep_test.cc
+++ b/src/libc/unistd/sleep_test.cc
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <unistd.h>
+#include <time.h>
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Rather than rely on "gtest/gtest.h" to include <time.h>, include it
explicitly, to ensure that time(2) is declared.
