### PR TITLE
Tweak inet_ntop's signature to match POSIX.

### DIFF
--- a/src/libc/arpa/inet/inet_ntop.c
+++ b/src/libc/arpa/inet/inet_ntop.c
@@ -92,7 +92,7 @@ static const char *inet_ntop_inet6(const struct in6_addr *restrict src,
 }
 
 const char *inet_ntop(int af, const void *restrict src, char *restrict dst,
-                      size_t size) {
+                      socklen_t size) {
   switch (af) {
     case AF_INET:
       return inet_ntop_inet(src, dst, size);


### PR DESCRIPTION
This changes inet_ntop's size parameter from size_t to socklen_t,
following POSIX:

http://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_ntop.html

In cloudlibc, these are typedefs for the same type, so there's no effective
change here.